### PR TITLE
[HotFix] getPostByParentId Order

### DIFF
--- a/src/cms.js
+++ b/src/cms.js
@@ -33,7 +33,7 @@ export async function getPostByParentId(
   orderBy = "menu_order"
 ) {
   const res = await fetch(
-    `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}?parent=${parent}&order=${order}&orderby=${orderBy}lang=${lang}`
+    `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}?parent=${parent}&order=${order}&orderby=${orderBy}&lang=${lang}`
   );
   return res.ok ? res.json() : null;
 }


### PR DESCRIPTION
## Description

Add default order to getPostByParentId

 - [x] order: `asc`,
 - [x] orderBy: `menu_order`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Screenshots

![S](https://user-images.githubusercontent.com/1779590/84627364-7a454c00-aeef-11ea-8c03-747c6f4f1246.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
