### PR TITLE
[HotFix] Add zoom control position

### DIFF
--- a/src/components/MapIt/index.js
+++ b/src/components/MapIt/index.js
@@ -57,6 +57,7 @@ function MapIt({
         geoLevel={geoId.split("-")[0]}
         geoIndexMapping={geoIndeces}
         indexColor={config.vulnerabilityIndexColor}
+        zoomControlPosition="topright"
         {...props}
       />
     </div>


### PR DESCRIPTION
## Description

- The recent version of hurumap-ui requires a definition for `zoomControlPosition` for Mapit, else it does not add zoomControl to the map. This PR add zoomControlPosition props to Mapit.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Desktop Screenshots



## Mobile Screenshots



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
